### PR TITLE
fix: usage pymorphy2

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ FROM amd64/ubuntu:20.04
 
 ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac python3-setuptools"
 ARG BUILD_PACKAGES="git python3-pip python3-wheel wget ca-certificates"
-ARG PIP_PACKAGE="flask pymorphy2 rhvoice-wrapper"
+ARG PIP_PACKAGE="flask pymorphy2 pymorphy2-dicts-ru rhvoice-wrapper"
 
 RUN apt-get update -y && \
     apt-get -y install --no-install-recommends $RUNTIME_PACKAGES && \

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,8 +1,8 @@
 # docker build -t aculeasis/rhvoice-rest:amd64 -f Dockerfile.amd64 .
 FROM amd64/ubuntu:20.04
 
-ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac"
-ARG BUILD_PACKAGES="git python3-pip python3-setuptools python3-wheel wget ca-certificates"
+ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac python3-setuptools"
+ARG BUILD_PACKAGES="git python3-pip python3-wheel wget ca-certificates"
 ARG PIP_PACKAGE="flask pymorphy2 rhvoice-wrapper"
 
 RUN apt-get update -y && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,7 +3,7 @@ FROM arm32v7/ubuntu:20.04
 
 ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac python3-setuptools"
 ARG BUILD_PACKAGES="git python3-pip python3-wheel wget ca-certificates"
-ARG PIP_PACKAGE="flask pymorphy2 rhvoice-wrapper"
+ARG PIP_PACKAGE="flask pymorphy2 pymorphy2-dicts-ru rhvoice-wrapper"
 
 RUN apt-get update -y && \
     apt-get -y install --no-install-recommends $RUNTIME_PACKAGES && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,8 +1,8 @@
 # docker build -t aculeasis/rhvoice-rest:arm32v7 -f Dockerfile.arm32v7 .
 FROM arm32v7/ubuntu:20.04
 
-ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac"
-ARG BUILD_PACKAGES="git python3-pip python3-setuptools python3-wheel wget ca-certificates"
+ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac python3-setuptools"
+ARG BUILD_PACKAGES="git python3-pip python3-wheel wget ca-certificates"
 ARG PIP_PACKAGE="flask pymorphy2 rhvoice-wrapper"
 
 RUN apt-get update -y && \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,7 +3,7 @@ FROM arm64v8/ubuntu:20.04
 
 ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac python3-setuptools"
 ARG BUILD_PACKAGES="git python3-pip python3-wheel wget ca-certificates"
-ARG PIP_PACKAGE="flask pymorphy2 rhvoice-wrapper"
+ARG PIP_PACKAGE="flask pymorphy2 pymorphy2-dicts-ru rhvoice-wrapper"
 
 RUN apt-get update -y && \
     apt-get -y install --no-install-recommends $RUNTIME_PACKAGES && \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,8 +1,8 @@
 # docker build -t aculeasis/rhvoice-rest:arm64v8 -f Dockerfile.arm64v8 .
 FROM arm64v8/ubuntu:20.04
 
-ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac"
-ARG BUILD_PACKAGES="git python3-pip python3-setuptools python3-wheel wget ca-certificates"
+ARG RUNTIME_PACKAGES="lame python3 locales opus-tools flac python3-setuptools"
+ARG BUILD_PACKAGES="git python3-pip python3-wheel wget ca-certificates"
 ARG PIP_PACKAGE="flask pymorphy2 rhvoice-wrapper"
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Close https://github.com/Aculeasis/rhvoice-rest/issues/6


Это происходит в момент импорта в https://github.com/vantu5z/RHVoice-dictionary/blob/23f8c3f56aba862b79149f12f9449f4748010de3/tools/preprocessing/words_forms.py#L12-L13  

Выяснил, что это из-за отсутствия `pkg_resources`:
```shell
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/pymorphy2/analyzer.py", line 200, in __init__
    path = self.choose_dictionary_path(path, lang)
  File "/usr/local/lib/python3.8/dist-packages/pymorphy2/analyzer.py", line 280, in choose_dictionary_path
    return lang_dict_path(lang)
  File "/usr/local/lib/python3.8/dist-packages/pymorphy2/analyzer.py", line 137, in lang_dict_path
    lang_paths = _lang_dict_paths()
  File "/usr/local/lib/python3.8/dist-packages/pymorphy2/analyzer.py", line 122, in _lang_dict_paths
    for pkg in _iter_entry_points('pymorphy2_dicts')
  File "/usr/local/lib/python3.8/dist-packages/pymorphy2/analyzer.py", line 114, in _iter_entry_points
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

все из-за того, что мы удаляем `python3-setuptools` в:
https://github.com/Aculeasis/rhvoice-rest/blob/e055e181e29172ef3f38920c33bfa3d3d36a47ae/Dockerfile.amd64#L23
https://github.com/Aculeasis/rhvoice-rest/blob/e055e181e29172ef3f38920c33bfa3d3d36a47ae/Dockerfile.amd64#L5

Перенес `python3-setuptools` из `BUILD_PACKAGES` в `RUNTIME_PACKAGES`.  
Также добавил `pymorphy2-dicts-ru` в `PIP_PACKAGE` как [рекомендуют в документации](https://pymorphy2.readthedocs.io/en/stable/user/guide.html#id2). 